### PR TITLE
styled-componentsのDefaultThemeに独自の型を注入

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,6 +21,12 @@
   "rules": {
     "@typescript-eslint/explicit-member-accessibility": 0,
     "@typescript-eslint/explicit-function-return-type": 0,
+    "@typescript-eslint/no-empty-interface": [
+      "error",
+      {
+        "allowSingleExtends": true
+      }
+    ],
     "prettier/prettier": [
       "error",
       {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { ThemeProvider } from 'styled-components';
 
 import { unregister } from './core';
-import { GlobalStyles } from './styles';
+import { GlobalStyles, theme } from './styles';
 
 ReactDOM.render(
-  <>
+  <ThemeProvider theme={theme}>
     <GlobalStyles />
     <div>Hello World</div>
-  </>,
+  </ThemeProvider>,
   document.getElementById('root')
 );
 

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -1,6 +1,7 @@
-import { createGlobalStyle } from 'styled-components';
+import { createGlobalStyle, css } from 'styled-components';
 
 export default createGlobalStyle`
+${({ theme }) => css`
   html {
     height: 100%;
 
@@ -11,8 +12,8 @@ export default createGlobalStyle`
       margin: 0;
 
       #root {
-        background: radial-gradient(#282c34cc, #282c34);
-        color: #282c34;
+        background: ${theme.colors.background};
+        color: ${theme.colors.black};
         display: flex;
         font-family: sans-serif;
         height: 100%;
@@ -21,4 +22,5 @@ export default createGlobalStyle`
       }
     }
   }
+`}
 `;

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,1 +1,2 @@
 export { default as GlobalStyles } from './global';
+export { default as theme } from './theme';

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,0 +1,10 @@
+export default {
+  colors: {
+    background: 'radial-gradient(#282c34cc, #282c34)',
+    black: '#282c34',
+    blue: '#a0e9fd',
+    lightBlue: '#caf3fe',
+    white: 'white',
+  },
+  transition: '0.3s',
+};

--- a/src/typings/theme.d.ts
+++ b/src/typings/theme.d.ts
@@ -1,0 +1,9 @@
+import 'styled-components';
+
+import { theme } from '../styles';
+
+type Theme = typeof theme;
+
+declare module 'styled-components' {
+  export interface DefaultTheme extends Theme {}
+}


### PR DESCRIPTION
- [x] DefaultThemeに独自の型をextendsする 
- [x] typescript-eslintの"no-empty-interface"/"allowSingleExtends"をtrueに設定する 