### PR TITLE
useSelectorのジェネリクス指定を除外

### DIFF
--- a/src/components/grid/block/index.tsx
+++ b/src/components/grid/block/index.tsx
@@ -2,8 +2,8 @@ import React, { FC } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { Dispatch, AnyAction } from 'redux';
 
-import { IReducer, selectBlock } from 'reducers';
-import { N, INDEX } from 'typings';
+import { selectBlock } from 'reducers';
+import { INDEX } from 'typings';
 
 import { Container } from './styles';
 
@@ -12,14 +12,8 @@ interface IProps {
   rowIndex: INDEX;
 }
 
-interface IState {
-  isActive: boolean;
-  isPuzzle: boolean;
-  value: N;
-}
-
 const Block: FC<IProps> = ({ colIndex, rowIndex }) => {
-  const state = useSelector<IReducer, IState>(
+  const state = useSelector(
     ({ challengeGrid, workingGrid, selectedBlock }) => ({
       isActive: selectedBlock
         ? selectedBlock[0] === rowIndex && selectedBlock[1] === colIndex

--- a/src/components/grid/index.tsx
+++ b/src/components/grid/index.tsx
@@ -2,30 +2,22 @@ import React, { FC, Children, useCallback, useEffect } from 'react';
 import useMousetrap from 'react-hook-mousetrap';
 import { useDispatch, useSelector } from 'react-redux';
 import { Dispatch, AnyAction } from 'redux';
-import { INDEX, BLOCK_COORDS, NUMBERS, N, GRID } from 'typings';
+import { INDEX, NUMBERS } from 'typings';
 
-import { createGrid, IReducer, selectBlock, fillBlock } from 'reducers';
+import { createGrid, selectBlock, fillBlock } from 'reducers';
 
 import Block from './block';
 import { Container, Row } from './styles';
 
-interface IState {
-  selectedBlock?: BLOCK_COORDS;
-  selectedValue: N;
-  solvedGrid?: GRID;
-}
-
 const Grid: FC = () => {
-  const state = useSelector<IReducer, IState>(
-    ({ selectedBlock, solvedGrid, workingGrid }) => ({
-      selectedBlock,
-      selectedValue:
-        workingGrid && selectedBlock
-          ? workingGrid[selectedBlock[0]][selectedBlock[1]]
-          : 0,
-      solvedGrid,
-    })
-  );
+  const state = useSelector(({ selectedBlock, solvedGrid, workingGrid }) => ({
+    selectedBlock,
+    selectedValue:
+      workingGrid && selectedBlock
+        ? workingGrid[selectedBlock[0]][selectedBlock[1]]
+        : 0,
+    solvedGrid,
+  }));
   const dispatch = useDispatch<Dispatch<AnyAction>>();
   const create = useCallback(() => dispatch(createGrid()), [dispatch]);
 

--- a/src/components/numbers/button/index.tsx
+++ b/src/components/numbers/button/index.tsx
@@ -3,28 +3,21 @@ import { useDispatch, useSelector } from 'react-redux';
 import { AnyAction, Dispatch } from 'redux';
 
 import { Button } from 'components';
-import { fillBlock, IReducer } from 'reducers';
-import { NUMBERS, BLOCK_COORDS, N } from '../../../typings';
+import { fillBlock } from 'reducers';
+import { NUMBERS } from '../../../typings';
 
 interface IProps {
   value: NUMBERS;
 }
 
-interface IState {
-  selectedBlock?: BLOCK_COORDS;
-  selectedValue: N;
-}
-
 const NumberButton: FC<IProps> = ({ value }) => {
-  const state = useSelector<IReducer, IState>(
-    ({ selectedBlock, workingGrid }) => ({
-      selectedBlock,
-      selectedValue:
-        workingGrid && selectedBlock
-          ? workingGrid[selectedBlock[0]][selectedBlock[1]]
-          : 0,
-    })
-  );
+  const state = useSelector(({ selectedBlock, workingGrid }) => ({
+    selectedBlock,
+    selectedValue:
+      workingGrid && selectedBlock
+        ? workingGrid[selectedBlock[0]][selectedBlock[1]]
+        : 0,
+  }));
 
   const dispatch = useDispatch<Dispatch<AnyAction>>();
 

--- a/src/typings/react-redux.d.ts
+++ b/src/typings/react-redux.d.ts
@@ -1,0 +1,6 @@
+import 'react-redux';
+import { IReducer } from '../reducers';
+
+declare module 'react-redux' {
+  interface DefaultRootState extends IReducer {}
+}


### PR DESCRIPTION
[この記事](https://qiita.com/Takepepe/items/6addcb1b0facb8c6ff1f)を参考にuseSelectorのジェネリクス指定を除外した。

- [x] Ambient Module 宣言で overload する
- [x] useSelecotrのジェネリクスを除外